### PR TITLE
Update linter and remove stale app

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,2 +1,0 @@
----
-_extends: .github:.github/stale.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,24 @@ on:
 
 jobs:
   lint:
-    name: Lint Code Base
+    name: Linting Code Base
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Lint Code Base
-        uses: github/super-linter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_NATURAL_LANGUAGE: false
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
+          sudo apt-get update
+          sudo apt-get -y install markdownlint
+
+      - name: Lint with yamllint
+        run: |
+          yamllint . --format github
+
+      - name: Lint with markdownlint
+        run: |
+          markdownlint `git ls-files *md`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Linting Code Base
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
@@ -19,14 +19,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install yamllint
-          sudo apt-get update
-          sudo apt-get -y install markdownlint
+          python -m pip install pymarkdownlnt yamllint
 
       - name: Lint with yamllint
         run: |
           yamllint . --format github
 
-      - name: Lint with markdownlint
+      - name: Lint with pymarkdownlint
         run: |
-          markdownlint `git ls-files *md`
+          pymarkdownlnt scan `git ls-files '*.md' ':!:*TEMPLATE/*md'`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    name: Linting Code Base
+    name: Lint Code Base
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
 
       - name: Lint with pymarkdownlint
         run: |
-          pymarkdownlnt scan `git ls-files '*.md' ':!:*TEMPLATE/*md'`
+          pymarkdownlnt -d MD013,MD041 scan `git ls-files '*.md' ':!:*TEMPLATE/*md'`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: Linting Code Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Code

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,0 @@
-{
-  "first-line-h1": false,
-  "line-length": false
-}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable


### PR DESCRIPTION
This pull request updates the linter used in the codebase and removes the stale app. The linter has been switched from Super-Linter to yamllint and markdownlint. The Super-Linter step has been replaced with two new steps: one for installing the necessary dependencies and another for running the linter with yamllint and markdownlint. This change improves the code quality and removes the unnecessary stale app.